### PR TITLE
Fix plc process config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,6 @@ openplc_users: [] # list of user dicts
 
 openplc_users_csv_template: users.csv.j2
 openplc_users_csv_template_dest: /tmp/openplc_users.csv
+
+openplc_hardware_layer: psm_linux
+openplc_hardware_layer_md5: "{{ (openplc_hardware_layer + '\n') | hash('md5') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,30 @@
     dest: "{{ openplc_deploy_dir }}/webserver/st_files/"
   loop: "{{ openplc_st_files }}"
   notify: restart openplc
+
+- name: check hardware layer
+  become: yes
+  stat:
+    path: "{{ openplc_deploy_dir }}/webserver/scripts/openplc_driver"
+    get_checksum: yes
+    checksum_algorithm: md5
+  register: _hardware_layer
+
+- name: configure hardware layer
+  become: yes
+  command: ./change_hardware_layer.sh "{{ openplc_hardware_layer }}"
+  when: _hardware_layer.stat.checksum != openplc_hardware_layer_md5
+  notify: restart openplc
+  args:
+    chdir: "{{ openplc_deploy_dir }}/webserver/scripts"
+
+- name: compile active PLC program
+  become: yes
+  command: ./compile_program.sh "{{ openplc_active_program }}"
+  when: openplc_active_program is defined and openplc_active_program | length > 0
+  notify: restart openplc
+  args:
+    chdir: "{{ openplc_deploy_dir }}/webserver/scripts"
   
 - name: copy openplc config files to remote host 
   become: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,38 +13,59 @@
   ignore_errors: true
   register: pip_is_installed
   changed_when: false
-  
+
 - block:
   - name: download get-pip.py
-    get_url: 
+    get_url:
       url: https://bootstrap.pypa.io/pip/2.7/get-pip.py
-      dest: /tmp
-      
+      dest: /tmp/get-pip.py
+
   - name: install pip
     become: yes
     command: "python2 /tmp/get-pip.py"
-  
+
   - name: delete get-pip.py
     file:
-      state: absent 
+      state: absent
       path: /tmp/get-pip.py
   when: pip_is_installed.rc != 0
 
-- name: install pip requirements 
+- name: install pip requirements
   become: yes
   pip:
     requirements: "{{ openplc_deploy_dir }}/requirements.txt"
     executable: pip2
 
-- name: install pip3
+- name: check to see if pip3 is already installed
   become: yes
-  apt:
-    name: python3-pip
-    state: present
-    update_cache: yes
-    cache_valid_time: 3600
+  command: "pip3 --version"
+  ignore_errors: true
+  register: pip3_is_installed
+  changed_when: false
 
-- name: install pip requirements 
+- block:
+  - name: download get-pip3.py
+    get_url:
+      url: https://bootstrap.pypa.io/pip/get-pip.py
+      dest: /tmp/get-pip3.py
+
+  - name: install pip
+    become: yes
+    command: "python3 /tmp/get-pip3.py"
+
+  - name: delete get-pip3.py
+    file:
+      state: absent
+      path: /tmp/get-pip3.py
+  when: pip3_is_installed.rc != 0
+
+- name: install pip requirements
+  become: yes
+  pip:
+    requirements: "{{ openplc_deploy_dir }}/requirements.txt"
+    executable: pip2
+
+- name: install pip3 requirements
   become: yes
   pip:
     name: "pymodbus"
@@ -61,8 +82,8 @@
   args:
     chdir: "{{ openplc_deploy_dir }}"
   when: not openplc_installed_marker.stat.exists or openplc_install_force
-  
-- name: copy st files to remote host 
+
+- name: copy st files to remote host
   become: yes
   copy:
     src: "{{ item }}"
@@ -93,8 +114,8 @@
   notify: restart openplc
   args:
     chdir: "{{ openplc_deploy_dir }}/webserver/scripts"
-  
-- name: copy openplc config files to remote host 
+
+- name: copy openplc config files to remote host
   become: yes
   copy:
     src: "{{ item.src }}"
@@ -102,7 +123,7 @@
   loop: "{{ openplc_config_files }}"
   notify: restart openplc
 
-- name: copy openplc template files to remote host 
+- name: copy openplc template files to remote host
   become: yes
   template:
     src: "{{ item.src }}"
@@ -129,8 +150,8 @@
     path: "{{ openplc_users_csv_template_dest }}"
     state: absent
   when: openplc_users | length > 0
-    
-- name: ensure openplc is running 
+
+- name: ensure openplc is running
   become: yes
   service:
     name: openplc


### PR DESCRIPTION
This PR adds configuration of the hardware layer and active program to the role.
These require calling shell scripts and compiling of C code which was previously not done.

Additionally this PR also switches to using the get-pip to install pip3. Previously we used the APT package, but the pip3 executable installed through APT seems to get deleted by the openplc install script causing issues when re-running the role.