### PR TITLE
Use manual restart logic for service restarting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for openplc
+openplc_restart_sleep_seconds: 60 # amount of time to sleep before starting the service when restarting
 openplc_install_force: no
 openplc_deploy_dir: /opt/OpenPLC_v3
 openplc_st_files: [] # List of files

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,20 @@
 ---
 # handlers file for openplc
-- name: restart openplc 
+- name: stop openplc
   become: yes
   service:
     name: openplc
-    state: restarted
+    state: stopped
+  listen: restart openplc
+
+- name: sleep between stop and start
+  pause:
+    seconds: "{{ openplc_restart_sleep_seconds }}"
+  listen: restart openplc
+
+- name: start openplc
+  become: yes
+  service:
+    name: openplc
+    state: started
+  listen: restart openplc


### PR DESCRIPTION
This PR changes the service restart behavior to use manual 
- stop
- wait
- start

process. We do this since the openplc service is a bit slow with releasing some of its ports, causing quick restarts to create broken PLC program processes.